### PR TITLE
Add ability to ignore hidden and locked elements in SVG files

### DIFF
--- a/gcodeplot.inx
+++ b/gcodeplot.inx
@@ -38,8 +38,10 @@
 
     </page>
     <page name="fitting" _gui-text="Fitting and Extracting">
+      <label appearance="header">Fitting</label>
+
       <param name="scale" type="enum" _gui-text="Scaling mode:" _gui-description="Method for scaling to print area (Default: none; should be 'none' if tool-offset option is set in cutter tab)">
-        <item value="n">none (needed if tool offset&gt;0)</item>
+        <item value="n">none (needed if tool offset &gt; 0)</item>
         <item value="f">fit</item>
         <item value="d">down-only</item>
       </param>
@@ -55,12 +57,16 @@
         <item value="center">center</item>
         <item value="top">right</item>
       </param>
-
+      <separator />
+      <label appearance="header">Extracting</label>
+      <param name="ignore-hidden" type="bool" gui-text="Ignore hidden elements" _gui-description="If checked, hidden layers, groups and elements will be discarded"></param>
+      <param name="ignore-locked" type="bool" gui-text="Ignore locked elements" _gui-description="If checked, locked layers, groups and elements will be discarded"></param>
       <hbox>
       <param name="boolean-extract-color" type="bool" gui-text="Extract only one color from drawing" _gui-description="Uncheck to include all colors; otherwise, choose the color to extract."></param>
       <spacer size="expand"/>
       <param name="extract-color" type="color" gui-text=" " appearance="colorbutton" _gui-description="The color to extract. Alpha values are discarded"></param>
       </hbox>
+
     </page>
     <page name="drawing" _gui-text="Drawing Settings">
       <param name="shading-threshold" type="float" min="0" max="1" precision="2" _gui-text="Shading threshold:" _gui-description="Shade whenever the shade is below this value, where 0=black and 1=white. To turn off shading, set to 0. (Default: 1, shade everything other than white).">1</param>

--- a/gcodeplot.py
+++ b/gcodeplot.py
@@ -714,11 +714,26 @@ def remove_hidden_SVGElements(svgTree):
                 remove_hidden_SVGElements(prop)
 
 
+def remove_locked_InkscapeSVGElements(svgTree:ET.Element):
+
+    prop_parents = svgTree.findall('*' + '/..')
+    for parent in prop_parents:
+        for prop in parent.findall('*'):
+
+            type = prop.get('{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}insensitive', None)
+        
+            if type is not None:
+                parent.remove(prop)     
+            else:
+                remove_locked_InkscapeSVGElements(prop)
+
+
 def generate_pen_data(svgTree, data, args, shader:Shader):
     penData = {}
     
     if svgTree is not None:
-        remove_hidden_SVGElements(svgTree) if args.ignore_hidden else svgTree
+        if args.ignore_hidden: remove_hidden_SVGElements(svgTree)
+        if args.ignore_locked: remove_locked_InkscapeSVGElements(svgTree)
         penData = parseSVG(svgTree, tolerance=args.tolerance, shader=shader, strokeAll=args.stroke_all, pens=args.pens, extractColor=args.extract_color if args.boolean_extract_color else None)
     else:
         penData = parseHPGL(data, dpi=args.input_dpi)
@@ -817,6 +832,8 @@ def parse_arguments(argparser:cArgumentParser):
     argparser.add_argument('-L', '--stroke-all', action=argparse.BooleanOptionalAction, default=False, help='stroke even regions specified by SVG to have no stroke')
     argparser.add_argument('-e', '--direction', metavar='ANGLE', default=None, type=lambda value: None if value.lower() == 'none' else float(value), help='for slanted pens: prefer to draw in given direction (degrees; 0=positive x, 90=positive y, none=no preferred direction) [default none]')
     argparser.add_argument('--ignore-hidden', action=argparse.BooleanOptionalAction, default=True, help='ignore hidden SVG elements')
+    argparser.add_argument('--ignore-locked', action=argparse.BooleanOptionalAction, default=True, help='ignore locked SVG elements (for Inkscape SVG only)')
+    
     
     argparser.add_argument('-o', '--optimization-time', metavar='T', default=60, type=int, help='max time to spend optimizing (seconds; set to 0 to turn off optimization) [default 60]')
     argparser.add_argument('-d', '--sort', action=argparse.BooleanOptionalAction, default=False, help='sort paths from inside to outside for cutting [default off]')

--- a/gcodeplot.py
+++ b/gcodeplot.py
@@ -702,12 +702,23 @@ def parse_svg_file(data):
     except:
         return None
 
+def remove_hidden_SVGElements(svgTree):
+
+    prop_parents = svgTree.findall('*' + '/..')
+    for parent in prop_parents:
+        for prop in parent.findall('*'):
+            type = prop.get('style', None)
+            if 'display:none' in str(type):
+                parent.remove(prop)
+            else:
+                remove_hidden_SVGElements(prop)
 
 
 def generate_pen_data(svgTree, data, args, shader:Shader):
     penData = {}
     
     if svgTree is not None:
+        remove_hidden_SVGElements(svgTree) if args.ignore_hidden else svgTree
         penData = parseSVG(svgTree, tolerance=args.tolerance, shader=shader, strokeAll=args.stroke_all, pens=args.pens, extractColor=args.extract_color if args.boolean_extract_color else None)
     else:
         penData = parseHPGL(data, dpi=args.input_dpi)
@@ -805,6 +816,7 @@ def parse_arguments(argparser:cArgumentParser):
     argparser.add_argument('-R', '--extract-color', metavar='C', default=None, type=parser.rgbFromColor, help='extract color (specified in SVG format , e.g., rgb(1,0,0) or #ff0000 or red)')
     argparser.add_argument('-L', '--stroke-all', action=argparse.BooleanOptionalAction, default=False, help='stroke even regions specified by SVG to have no stroke')
     argparser.add_argument('-e', '--direction', metavar='ANGLE', default=None, type=lambda value: None if value.lower() == 'none' else float(value), help='for slanted pens: prefer to draw in given direction (degrees; 0=positive x, 90=positive y, none=no preferred direction) [default none]')
+    argparser.add_argument('--ignore-hidden', action=argparse.BooleanOptionalAction, default=True, help='ignore hidden SVG elements')
     
     argparser.add_argument('-o', '--optimization-time', metavar='T', default=60, type=int, help='max time to spend optimizing (seconds; set to 0 to turn off optimization) [default 60]')
     argparser.add_argument('-d', '--sort', action=argparse.BooleanOptionalAction, default=False, help='sort paths from inside to outside for cutting [default off]')

--- a/gcodeplot.py
+++ b/gcodeplot.py
@@ -816,8 +816,8 @@ def parse_arguments(argparser:cArgumentParser):
     argparser.add_argument('-R', '--extract-color', metavar='C', default=None, type=parser.rgbFromColor, help='extract color (specified in SVG format , e.g., rgb(1,0,0) or #ff0000 or red)')
     argparser.add_argument('-L', '--stroke-all', action=argparse.BooleanOptionalAction, default=False, help='stroke even regions specified by SVG to have no stroke')
     argparser.add_argument('-e', '--direction', metavar='ANGLE', default=None, type=lambda value: None if value.lower() == 'none' else float(value), help='for slanted pens: prefer to draw in given direction (degrees; 0=positive x, 90=positive y, none=no preferred direction) [default none]')
-    argparser.add_argument('--ignore-hidden', action=argparse.BooleanOptionalAction, default=True, help='ignore hidden SVG elements')
-    argparser.add_argument('--ignore-locked', action=argparse.BooleanOptionalAction, default=True, help='ignore locked SVG elements (for Inkscape SVG only)')
+    argparser.add_argument('--ignore-hidden', action=CustomBooleanAction, default=True, help='ignore hidden SVG elements')
+    argparser.add_argument('--ignore-locked', action=CustomBooleanAction, default=True, help='ignore locked SVG elements (for Inkscape SVG only)')
     
     
     argparser.add_argument('-o', '--optimization-time', metavar='T', default=60, type=int, help='max time to spend optimizing (seconds; set to 0 to turn off optimization) [default 60]')


### PR DESCRIPTION
Add ability to ignore hidden and locked elements in SVG files.

In Illustrator, make sure when you export as SVG, under `Advanced Options` set `CSS Properties` to `Style Attributes`.

For locked elements, it only works with Inkscape SVGs as I don't know how Illustrator tags their locked layers. 
